### PR TITLE
chore: avoid plain-objects for attributes

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -71,8 +71,7 @@
           <p>This function will produce a <code>vnode</code> value.</p>
           <small>output:</small>
           <script>test(({ h }, appendChild) => {
-            var vnode = h('a',
-              { href: '#' }, 'This is', 'JSON');
+            var vnode = h('a', ['href', '#'], 'This is', 'JSON');
 
             appendChild(document.createTextNode(JSON.stringify(vnode)));
           });</script>
@@ -89,13 +88,13 @@
           <small>output:</small>
           <script>test(({ pre }, appendChild) => {
             appendChild(pre(['root', null, [
-              ['children', { boolean: true }, [
-                ['node', { string: 'value' }],
-                ['node', null, [
+              ['children', ['boolean', true], [
+                ['node', ['string', 'value']],
+                ['node', null,
                   '\nSome text: ',
-                  ['subnode', { number: 1 }],
+                  ['subnode', ['number', 1]],
                   'More text here.\n'
-                ]],
+                ],
               ]]
             ]]));
           });</script>
@@ -124,7 +123,7 @@
 
             var tag = bind(render, { Test });
 
-            appendChild(tag(['Test', { style: 'color:red' }, [42]]));
+            appendChild(tag(['Test', ['style', 'color:red'], [42]]));
           });</script>
         </dd>
         <dd>
@@ -183,7 +182,7 @@
           <small>output:</small>
           <fieldset id="test6"></fieldset>
           <script>test(({ mount }, appendChild) => {
-            var style = 'text-decoration:underline';
+            var css = 'text-decoration:underline';
 
             mount(test6, [
               'Some text ',
@@ -193,7 +192,7 @@
                 'because',
                 ' ',
                 ['em', null, ['it is']],
-                [' ', [['strong', { style }, 'possible!']]],
+                [' ', [['strong', ['style', css], 'possible!']]],
               ],
             ]);
             appendChild();
@@ -258,18 +257,18 @@
               var len = Math.round(Math.random() * 10) + 1;
 
               return Array.from({ length: len })
-                .map((_, k) => ['li', {
-                  update: ['animated', 'fadeIn'],
-                  enter: ['animated', 'fadeIn'],
-                  exit: ['animated', 'fadeOut', 'faster'],
-                  style: {
+                .map((_, k) => ['li', [
+                  'update', ['animated', 'fadeIn'],
+                  'enter', ['animated', 'fadeIn'],
+                  'exit', ['animated', 'fadeOut', 'faster'],
+                  'style', {
                     transition: 'color .2s',
                     color: [
                       'red',
                       'blue',
                     ][+(Math.random() > 0.5)],
                   },
-                }, ['Item ', k + 1]]);
+                ], ['Item ', k + 1]]);
             }
 
             function view() {
@@ -296,10 +295,10 @@
             }
 
             appendChild(tag(['label', null, [
-              ['input', {
-                onclick: toggle,
-                type: 'checkbox'
-              }],
+              ['input', [
+                'onclick', toggle,
+                'type', 'checkbox'
+              ]],
               'Play',
             ]]));
           });</script>
@@ -335,18 +334,18 @@
           <script>test(({ render }, appendChild) => {
             appendChild(render(['b', null, ['Bold, ']]));
             appendChild(render(['em', null, [['span', null, 'Italic ']]]));
-            appendChild(render(['span', { style: 'color:red' }, '& Colored.']));
+            appendChild(render(['span', ['style', 'color:red'], '& Colored.']));
           });</script>
         </dd>
         <dd>
           <p>SVG support is handled for you. However, elements without an <code>svg</code> root requires <code>true</code> as second argument.</p>
           <small>output:</small>
           <script>test(({ mount, render }, appendChild) => {
-            var attrs = {
-              width: 16,
-              height: 16,
-              viewBox: '0 0 32 32',
-            };
+            var attrs = [
+              'width', 16,
+              'height', 16,
+              'viewBox', '0 0 32 32',
+            ];
 
             var icons = {
               play: 'M6 4l20 12-20 12z',
@@ -354,9 +353,7 @@
             };
 
             function getIcon(name) {
-              return ['path', {
-                d: icons[name],
-              }];
+              return ['path', ['d', icons[name]]];
             }
 
             appendChild(render(['svg', attrs, [getIcon('play')]]));
@@ -371,7 +368,7 @@
           <p>All functions are executed during <code>render</code> calls.</p>
           <small>output:</small>
           <script>test(({ render }, appendChild) => {
-            var Em = Array.prototype.concat.bind(['em']);
+            var Em = (props, children) => ['em', props, children];
 
             function Del(props, children) {
               return ['del', null, [[Em, props, children]]];
@@ -397,7 +394,7 @@
             var tag = bind(render, listeners());
 
             function Button(label, onClick) {
-              return ['button', { onclick: onClick }, label];
+              return ['button', ['onclick', onClick], label];
             }
 
             function remove(target) {
@@ -447,7 +444,7 @@
             }
 
             appendChild(tag(['button',
-              { onclick: click }, 'Click me']));
+              ['onclick', click], 'Click me']));
           });</script>
         </dd>
         <dd>
@@ -465,18 +462,18 @@
             var calls = [];
 
             function Button(label) {
-              return ['button', {
-                onclick: () => calls.shift()(),
-                oncreate: () => {
+              return ['button', [
+                'onclick', () => calls.shift()(),
+                'oncreate', () => {
                   info.innerHTML = 'Created.';
                 },
-                onupdate: () => {
+                'onupdate', () => {
                   info.innerHTML = 'Updated.';
                 },
-                ondestroy: () => {
+                'ondestroy', () => {
                   info.innerHTML = 'Destroyed.';
                 },
-              }, label];
+              ], label];
             }
 
             calls.push(() => {
@@ -510,15 +507,15 @@
               style: styles,
             }));
 
-            var props = {
-              style: {
+            var props = [
+              'style', {
                 color: 'purple',
               },
-              class: {
+              'class', {
                 present: 1,
                 hidden: 0,
               },
-            };
+            ];
 
             appendChild(pre(['span', props, 'EXAMPLE'], null, tag));
           });</script>
@@ -540,14 +537,14 @@
               }));
 
             function append() {
-              var item = tag(['li', {
-                enter: ['animated', 'fadeIn'],
-                exit: ['animated', 'slideUp', 'faster'],
-              }, [
+              var item = tag(['li', [
+                'enter', ['animated', 'fadeIn'],
+                'exit', ['animated', 'slideUp', 'faster'],
+              ], [
                 ['button',
-                  { onclick: () => {
+                  ['onclick', () => {
                     unmount(item);
-                  } }, 'Remove'],
+                  }], 'Remove'],
                 ['span', null, ['EXAMPLE']],
               ]]);
 
@@ -555,7 +552,7 @@
             }
 
             var button = ['button',
-              { onclick: append }, 'Add item'];
+              ['onclick', append], 'Add item'];
 
             mount('#test4', tag(['li', null, [button]]));
             appendChild();
@@ -570,9 +567,9 @@
                 json: value => JSON.stringify(value),
               }));
 
-            var props = {
-              json: [1, 2, [3, 4, [5]]],
-            };
+            var props = [
+              'json', [1, 2, [3, 4, [5]]],
+            ];
 
             appendChild(pre(['span', props, 'EXAMPLE'], null, attrs));
           });</script>
@@ -583,19 +580,19 @@
           <script>test(({ pre, bind, render, attributes }, appendChild) => {
             var attrs = bind(render, attributes());
 
-            var props = {
-              data: {
+            var props = [
+              'data', {
                 title: 'Example',
               },
-              arrays: ['TESTING'],
-              objects: {
+              'arrays', ['TESTING'],
+              'objects', {
                 prop: 'A string.',
                 nested: {
                   key: 'value',
                   values: [1, 2, 3],
                 },
               },
-            };
+            ];
 
             appendChild(pre(['span', props, 'EXAMPLE'], null, attrs));
           });</script>

--- a/src/index.js
+++ b/src/index.js
@@ -14,12 +14,12 @@ import { addEvents } from './lib/events';
 
 export const h = (tag = 'div', attrs = null, ...children) => {
   if (isScalar(attrs)) return [tag, null, [attrs].concat(children).filter(x => !isNot(x))];
-  if (isArray(attrs)) return [tag, null, attrs];
+  if (isArray(attrs) && !children.length) return [tag, null, attrs];
   return [tag, attrs || null, children];
 };
 
 export const pre = (vnode, svg, cb = render) => {
-  return cb(['pre', { class: 'highlight' }, format(cb(vnode, svg).outerHTML)], svg);
+  return cb(['pre', ['class', 'highlight'], format(cb(vnode, svg).outerHTML)], svg);
 };
 
 export const bind = (tag, ...hooks) => {
@@ -44,6 +44,10 @@ export const attributes = opts => apply(invokeProps, 3, opts);
 export {
   raf, tick, format,
 } from './lib/util';
+
+export {
+  toProxy as proxy,
+} from './lib/shared';
 
 export {
   mountElement as mount,

--- a/src/lib/attrs.js
+++ b/src/lib/attrs.js
@@ -2,30 +2,33 @@ import {
   isEmpty, isObject, isFunction, isScalar, isDiff, isArray, camelCase,
 } from './util';
 
-import { XLINK_PREFIX, XLINK_NS } from './shared';
+import { XLINK_PREFIX, XLINK_NS, toKeys } from './shared';
 
 export function assignProps(target, attrs, svg, cb) {
-  Object.keys(attrs).forEach(prop => {
-    if (prop === 'key') return;
+  for (let i = 0; i < attrs.length; i += 2) {
+    const prop = attrs[i];
+    const val = attrs[i + 1];
+
+    if (prop === 'key') continue;
     if (prop === 'ref') {
       target.oncreate = el => {
-        attrs[prop].current = el;
+        val.current = el;
       };
     } else if (prop === '@html') {
-      target.innerHTML = attrs[prop];
+      target.innerHTML = val;
     } else if (prop.indexOf('class:') === 0) {
-      if (!attrs[prop]) {
+      if (!val) {
         target.classList.remove(prop.substr(6));
       } else {
         target.classList.add(prop.substr(6));
       }
     } else if (prop.indexOf('style:') === 0) {
-      target.style[camelCase(prop.substr(6))] = attrs[prop];
+      target.style[camelCase(prop.substr(6))] = val;
     } else {
       const name = prop.replace('@', 'data-').replace(XLINK_PREFIX, '');
 
       // eslint-disable-next-line no-nested-ternary
-      let value = attrs[prop] !== true ? attrs[prop] : (name.includes('-') ? true : name);
+      let value = val !== true ? val : (name.includes('-') ? true : name);
       if (isObject(value)) {
         value = (isFunction(cb) && cb(target, name, value)) || value;
         value = value !== target ? value : null;
@@ -39,32 +42,35 @@ export function assignProps(target, attrs, svg, cb) {
       if (svg && prop !== name) {
         if (removed) target.removeAttributeNS(XLINK_NS, name);
         else target.setAttributeNS(XLINK_NS, name, value);
-        return;
+        continue;
       }
 
       if (removed) target.removeAttribute(name);
       else if (isScalar(value)) target.setAttribute(name, value);
     }
-  });
+  }
 }
 
 export function updateProps(target, prev, next, svg, cb) {
-  const keys = Object.keys(prev).concat(Object.keys(next));
+  const [old, keys] = [prev, next].map(toKeys);
+  const set = prev.concat(next);
+  const data = new Map();
+  const props = [];
 
-  let changed;
-  const props = keys.reduce((all, k) => {
-    if (k !== '@html') {
-      if (k in prev && !(k in next)) {
-        all[k] = null;
-        changed = true;
-      } else if (isDiff(prev[k], next[k], true)) {
-        all[k] = next[k];
-        changed = true;
-      }
-    }
-    return all;
-  }, {});
+  for (let i = 0; i < set.length; i += 2) {
+    const k = set[i];
+    const v = set[i + 1];
 
-  if (changed) assignProps(target, props, svg, cb);
-  return changed;
+    /* istanbul ignore else */
+    if (old.includes(k)) {
+      if (!data.has(k)) data.set(k, v);
+      if (!keys.includes(k)) props.push(k, null);
+      else if (isDiff(data.get(k), v, true)) props.push(k, v);
+    } else if (isDiff(data.get(k), v, true)) props.push(k, v);
+  }
+
+  if (props.length > 0) {
+    assignProps(target, props, svg, cb);
+    return true;
+  }
 }

--- a/src/lib/shared.js
+++ b/src/lib/shared.js
@@ -1,8 +1,7 @@
+export const RE_NUMBER = /^\d+$/;
 export const RE_XML_SPLIT = /(>)(<)(\/*)/g;
 export const RE_XML_CLOSE_END = /.+<\/\w[^>]*>$/;
 export const RE_XML_CLOSE_BEGIN = /^<\/\w/;
-
-export const SVG_NS = 'http://www.w3.org/2000/svg';
 
 export const XLINK_PREFIX = /^xlink:?/;
 export const XLINK_NS = 'http://www.w3.org/1999/xlink';
@@ -26,6 +25,8 @@ export const CLOSE_TAGS = [
   'wbr',
 ];
 
+export const IS_PROXY = Symbol('$$proxy');
+
 export const isArray = value => Array.isArray(value);
 export const isString = value => typeof value === 'string';
 export const isFunction = value => typeof value === 'function';
@@ -34,11 +35,15 @@ export const isPlain = value => value !== null && Object.prototype.toString.call
 export const isObject = value => value !== null && (typeof value === 'function' || typeof value === 'object');
 export const isScalar = value => isString(value) || typeof value === 'number' || typeof value === 'boolean';
 
+export function isTuple(value) {
+  if (!(isArray(value) && isEven(value.length))) return false;
+  return toKeys(value).every(isString);
+}
+
 export function isNode(value) {
-  if (!isArray(value)) return false;
-  if (typeof value[0] === 'function') return true;
-  if (value[1] === null || isPlain(value[1])) return true;
-  return false;
+  if (isArray(value) && isFunction(value[0])) return true;
+  if (!value || !(isArray(value) && isString(value[0]))) return false;
+  return value[1] === null || (value.length >= 2 && (isPlain(value[1]) || isTuple(value[1])));
 }
 
 export function isEmpty(value) {
@@ -51,3 +56,59 @@ export function isEmpty(value) {
 }
 
 export const isBlock = value => isArray(value) && !isNode(value);
+export const isEven = value => value % 2 === 0;
+
+export function toProxy(values) {
+  if (!isArray(values)) values = [];
+  if (IS_PROXY in values) return values;
+
+  Object.defineProperty(values, IS_PROXY, { value: true });
+
+  return new Proxy(values, {
+    get(target, prop) {
+      if (prop === Symbol.for('nodejs.util.inspect.custom')) return target;
+      if (prop === Symbol.isConcatSpreadable) return target;
+      if (prop === Symbol.toStringTag) return target;
+      if (prop === Symbol.iterator) return target[Symbol.iterator].bind(target);
+      if (prop === 'filter') return target.filter.bind(target);
+      if (prop === 'length') return target.length;
+      if (RE_NUMBER.test(prop)) return target[prop];
+
+      for (let i = 0; i < target.length; i += 2) {
+        /* istanbul ignore else */
+        if (target[i] === prop) return target[i + 1];
+      }
+    },
+    set(target, prop, value) {
+      if (RE_NUMBER.test(prop)) {
+        target[prop] = value;
+        return true;
+      }
+
+      for (let i = 0; i < target.length; i += 2) {
+        if (target[i] === prop) {
+          target[i + 1] = value;
+          return true;
+        }
+      }
+
+      target.push(prop, value);
+      return true;
+    },
+  });
+}
+
+export function toProps(value) {
+  return Object.entries(value).reduce((memo, [k, v]) => {
+    memo.push(k, v);
+    return memo;
+  }, []);
+}
+
+export function toKeys(value) {
+  return value.filter((_, i) => isEven(i));
+}
+
+export function toFragment(vnode) {
+  return vnode.slice(2);
+}

--- a/src/lib/util.js
+++ b/src/lib/util.js
@@ -2,7 +2,7 @@ import {
   RE_XML_SPLIT,
   RE_XML_CLOSE_END,
   RE_XML_CLOSE_BEGIN,
-  isNot, isBlock, isPlain, isEmpty, isNode, isArray,
+  isNot, isBlock, isPlain, isEmpty, isNode, isArray, isTuple,
 } from './shared';
 
 import Fragment from './fragment';
@@ -10,7 +10,7 @@ import Fragment from './fragment';
 export * from './shared';
 
 export function flat(value) {
-  return !isArray(value) ? value : value.reduce((memo, n) => memo.concat(isNode(n) ? [n] : flat(n)), []);
+  return !isArray(value) ? value : value.reduce((memo, n) => memo.concat(isNode(n) || isTuple(n) ? [n] : flat(n)), []);
 }
 
 export function zip(nodes, prev, next, offset, cb, d = 0) {

--- a/tests/e2e/main.test.js
+++ b/tests/e2e/main.test.js
@@ -11,7 +11,7 @@ function summarize(script) {
 
   somedom.mount(parentNode, ['details', null, [
     ['summary', null, ['View executed code']],
-    ['pre', { class: 'highlight' }, format(code)],
+    ['pre', ['class', 'highlight'], format(code)],
   ]]);
 }
 
@@ -46,11 +46,11 @@ window.addEventListener('DOMContentLoaded', () => {
       t.cb(somedom, x => appendChild(t.el, x));
     } catch (e) {
       console.log(e);
-      appendChild(t.el, somedom.render(['div', { class: 'error' }, e.toString()]));
+      appendChild(t.el, somedom.render(['div', ['class', 'error'], e.toString()]));
     }
   });
 
   window.hijs = '.highlight';
 
-  somedom.mount('head', ['script', { src: '//cdn.rawgit.com/cloudhead/hijs/0eaa0031/hijs.js' }]);
+  somedom.mount('head', ['script', ['src', '//cdn.rawgit.com/cloudhead/hijs/0eaa0031/hijs.js']]);
 });

--- a/tests/unit/00_util.test.js
+++ b/tests/unit/00_util.test.js
@@ -136,7 +136,7 @@ describe('util', () => {
       expect(isNode(['x'])).to.be.false;
       expect(isNode(['x', 'y'])).to.be.false;
       expect(isNode(['x', 'y', 'z'])).to.be.false;
-      expect(isNode(['x', ['y', 'z']])).to.be.false;
+      expect(isNode(['x', ['y', 'z']])).to.be.true;
       expect(isNode(['a', undefined])).to.be.false;
       expect(isNode(['a', null])).to.be.true;
       expect(isNode(['a', {}])).to.be.true;

--- a/tests/unit/01_main.test.js
+++ b/tests/unit/01_main.test.js
@@ -44,9 +44,9 @@ describe('somedom', () => {
         sample = encodeText(sample, false);
       }
 
-      expect(pre(['div', null, [
-        ['span', { foo: 'bar', baz: true }, ['TEXT']],
-      ]]).outerHTML).to.eql(`<pre class="highlight">${sample}</pre>`);
+      expect(pre(['div', null,
+        ['span', ['foo', 'bar', 'baz', true], 'TEXT'],
+      ]).outerHTML).to.eql(`<pre class="highlight">${sample}</pre>`);
     });
   });
 
@@ -104,7 +104,7 @@ describe('somedom', () => {
       mount(document.body, ['\n']);
 
       const c = ['\n'];
-      const d = ['\n', ['p', { class: 'ok' }, ['OSOM']], '\n'];
+      const d = ['\n', ['p', ['class', 'ok'], ['OSOM']], '\n'];
 
       await patch(document.body, c, d);
       expect(document.body.outerHTML).to.eql('<body>\n<p class="ok">OSOM</p>\n</body>');
@@ -127,14 +127,14 @@ describe('somedom', () => {
         ['nav', null, [
           ['ul', null, [
             ['li', null, ['Home']],
-            ['fragment', { key: 'user-menu' }, [
+            ['fragment', ['key', 'user-menu'], [
               '\n',
               ['li', null, ['Profile']],
               '\n',
             ]],
           ]],
         ]],
-        ['fragment', { key: 'flash-info' }, ['\n']],
+        ['fragment', ['key', 'flash-info'], ['\n']],
         ['main', null, ['MARKUP']],
       ];
 
@@ -150,10 +150,10 @@ describe('somedom', () => {
         ['nav', null, [
           ['ul', null, [
             ['li', null, ['Home']],
-            ['fragment', { key: 'user-menu' }, ['\n']],
+            ['fragment', ['key', 'user-menu'], ['\n']],
           ]],
         ]],
-        ['fragment', { key: 'flash-info' }, [['p', null, 'Done.'], '\n']],
+        ['fragment', ['key', 'flash-info'], [['p', null, 'Done.'], '\n']],
         ['main', null, ['FORM']],
       ];
 
@@ -195,7 +195,7 @@ describe('somedom', () => {
       data.map(x => td.when(rm(x.id)).thenDo(() => filter(x.id)));
 
       function view() {
-        const partial = ['ul', null, data.map(x => ['li', { onclick: () => rm(x.id) }, x.value])];
+        const partial = ['ul', null, data.map(x => ['li', ['onclick', () => rm(x.id)], x.value])];
 
         return useFragment
           ? [partial]

--- a/tests/unit/03_attrs.test.js
+++ b/tests/unit/03_attrs.test.js
@@ -22,36 +22,36 @@ describe('attrs', () => {
 
   describe('assignProps', () => {
     it('should keep empty attributes', () => {
-      assignProps(div, { foo: '' });
+      assignProps(div, ['foo', '']);
       expect(div.getAttribute('foo')).to.eql('');
     });
 
     it('should append given attributes', () => {
-      assignProps(div, { foo: 'bar' });
+      assignProps(div, ['foo', 'bar']);
       expect(div.getAttribute('foo')).to.eql('bar');
     });
 
     it('should skip special attributes, like key', () => {
-      assignProps(div, { key: 'bar' });
+      assignProps(div, ['key', 'bar']);
       expect(div.getAttribute('key')).to.be.null;
     });
 
     it('should pass special attributes to given callback', () => {
       const spy = td.func('callback');
 
-      assignProps(div, { baz: ['buzz'] }, null, spy);
+      assignProps(div, ['baz', ['buzz']], null, spy);
       expect(td.explain(spy).callCount).to.eql(1);
     });
 
     it('should handle boolean attributes as expected', () => {
-      assignProps(div, { test: true });
+      assignProps(div, ['test', true]);
       expect(div.getAttribute('test')).to.eql('test');
     });
 
     it('should handle attributes from svg-elements too', () => {
       const svg = document.createElementNS('xmlns', 'svg');
 
-      assignProps(svg, { 'xlink:href': 'z' }, true);
+      assignProps(svg, ['xlink:href', 'z'], true);
       expect(svg.getAttribute('href')).to.eql('z');
     });
 
@@ -59,12 +59,12 @@ describe('attrs', () => {
       div.setAttribute('foo', 'bar');
       div.setAttribute('hrez', 'baz');
 
-      assignProps(div, {
-        foo: false,
-        'xlink:href': null,
-        notFalsy: 0,
-        emptyValue: '',
-      }, true);
+      assignProps(div, [
+        'foo', false,
+        'xlink:href', null,
+        'notFalsy', 0,
+        'emptyValue', '',
+      ], true);
 
       expect(div.getAttribute('foo')).to.eql(null);
       expect(div.getAttribute('href')).to.eql(null);
@@ -73,28 +73,24 @@ describe('attrs', () => {
     });
 
     it('should handle the @html prop', () => {
-      assignProps(div, {
-        '@html': '<b>OSOM</b>',
-      }, true);
+      assignProps(div, ['@html', '<b>OSOM</b>'], true);
 
       expect(div.outerHTML).to.eql('<div><b>OSOM</b></div>');
     });
 
     it('should skip :static props', () => {
-      assignProps(div, {
-        ':disabled': true,
-      }, true);
+      assignProps(div, [':disabled', true], true);
 
       expect(div.outerHTML).to.not.contains(' disabled');
     });
 
     it('should handle class/style directives', () => {
-      assignProps(div, {
-        'style:backgroundColor': 'red',
-        'style:font-size': '12px',
-        'class:enabled': 1,
-        'class:disabled': null,
-      });
+      assignProps(div, [
+        'style:backgroundColor', 'red',
+        'style:font-size', '12px',
+        'class:enabled', 1,
+        'class:disabled', null,
+      ]);
 
       expect(div.outerHTML).to.contains(' class="enabled"');
       expect(div.outerHTML).to.contains(' style="background-color: red; font-size: 12px;"');
@@ -107,9 +103,16 @@ describe('attrs', () => {
       div.setAttribute('foo', 'bar');
       div.setAttribute('href', 'baz');
 
-      updateProps(div, div.attributes, { foo: 'BAR', a: 'b' });
+      const attrs = Object.keys(div.attributes).reduce((memo, cur) => memo.concat(cur, div.attributes[cur]), []);
+
+      updateProps(div, attrs, ['foo', 'BAR', 'a', 'b']);
       expect(div.getAttribute('foo')).to.eql('BAR');
       expect(div.getAttribute('a')).to.eql('b');
+    });
+
+    it('should assign new props', () => {
+      updateProps(div, [], ['class', 'red']);
+      expect(div.getAttribute('class')).to.eql('red');
     });
   });
 });


### PR DESCRIPTION
Turns out objects for props were a bad idea: https://www.builder.io/blog/monomorphic-javascript

Instead, we'll use simple arrays for props, and through a `Proxy` we provide a way to retrieve those in a simple manner.

Given `['href', '#']` as props, they can be read as `props.href` using this technique, etc.